### PR TITLE
chore(community): add SECURITY policy and issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,131 @@
+name: Bug report
+description: Report a reproducible bug or regression in an a-novel project.
+title: "bug: <short description>"
+labels:
+  - bug
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report!
+
+        **Before you continue:**
+        - If you suspect a **security vulnerability**, please do not open a public issue. Follow
+          the [security policy](https://github.com/a-novel/.github/blob/master/SECURITY.md)
+          to report it privately.
+        - Please search [existing issues](https://github.com/a-novel) first to avoid duplicates.
+        - For questions or general support, please use [Discord](https://discord.gg/rp4Qr8cA)
+          rather than the issue tracker.
+
+  - type: input
+    id: affected-repo
+    attributes:
+      label: Affected repository
+      description: Which repository in the `a-novel` or `a-novel-kit` org does this bug live in?
+      placeholder: e.g. a-novel/service-authentication, a-novel-kit/golib, a-novel/uikit
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: |
+        Which version, release tag, container image tag, or commit SHA are you running? If you
+        are running from `master`, paste the commit SHA from `git rev-parse HEAD`.
+      placeholder: e.g. v1.4.2, master @ a1b2c3d, ghcr.io/a-novel/service-x:1.4.2
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear and concise description of what the bug is.
+      placeholder: |
+        When I do X, I expect Y, but I see Z instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Minimal, complete, reproducible steps. If a code snippet or shell session reproduces it,
+        paste it as a fenced code block. The more precise this is, the faster we can fix it.
+      placeholder: |
+        1. Clone repo and check out commit X
+        2. Run `make …`
+        3. Send request `…`
+        4. Observe error `…`
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include error messages, stack traces, or screenshots.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        Anything that might be relevant to reproducing the issue.
+      value: |
+        - OS:
+        - Architecture (amd64, arm64):
+        - Go version (`go version`) — if applicable:
+        - Node version (`node --version`) — if applicable:
+        - Browser (name + version) — if applicable:
+        - Container runtime (Docker / Podman + version) — if applicable:
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: |
+        Paste any relevant logs, stack traces, or command output here. **Please redact any
+        secrets, tokens, or personal data** before submitting.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context, links, or screenshots about the problem here.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: |
+        By submitting this issue, you agree to follow the project's
+        [Code of Conduct](https://github.com/a-novel/.github/blob/master/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct.
+          required: true
+        - label: I have searched existing issues and confirmed this is not a duplicate.
+          required: true
+        - label: This is not a security vulnerability (security reports must follow the security policy).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/a-novel/.github/blob/master/SECURITY.md
+    about: |
+      Please do not open public issues for security vulnerabilities. Follow the org security
+      policy to report privately via GitHub private vulnerability reporting or email.
+  - name: Questions, discussions and community support
+    url: https://discord.gg/rp4Qr8cA
+    about: |
+      For usage questions, design discussions, or general help, join us on Discord — the issue
+      tracker is for actionable bug reports and feature requests only.
+  - name: Code of Conduct
+    url: https://github.com/a-novel/.github/blob/master/CODE_OF_CONDUCT.md
+    about: |
+      All participation in this project is governed by our Code of Conduct. Please read it
+      before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,111 @@
+name: Feature request
+description: Suggest an idea, enhancement, or new capability for an a-novel project.
+title: "feat: <short description>"
+labels:
+  - enhancement
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a feature!
+
+        **Before you continue:**
+        - Please search [existing issues](https://github.com/a-novel) and the
+          [roadmap](https://github.com/orgs/a-novel/projects/7) first to avoid duplicates.
+        - For open-ended discussion or ideas you are not yet sure about, please use
+          [Discord](https://discord.gg/rp4Qr8cA) — once an idea has crystallised into a concrete
+          ask, file it here.
+
+  - type: input
+    id: target-repo
+    attributes:
+      label: Target repository
+      description: |
+        Which repository (or repositories) should this feature land in? If you are not sure,
+        leave a best guess and a maintainer will reassign.
+      placeholder: e.g. a-novel/service-authentication, a-novel-kit/golib, a-novel/uikit
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: |
+        What problem are you trying to solve? Describe the user-facing pain point or the gap in
+        the current API, not the implementation you have in mind.
+      placeholder: |
+        Today, when I try to do X, I have to do Y, which is painful because …
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: |
+        Describe the change you would like to see. API shape, UX flow, configuration knobs —
+        whatever fits the kind of change you are proposing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        Have you tried other approaches or workarounds? What did and did not work? Are there
+        existing tools or libraries that solve a similar problem in a different way?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: Would this be a breaking change?
+      description: |
+        A "breaking change" is one that removes or renames an existing public symbol, changes
+        the semantics of a public API, or otherwise requires existing consumers to update their
+        code or configuration.
+      options:
+        - "No — fully backwards compatible"
+        - "Yes — but staged migration is possible"
+        - "Yes — hard break, no migration path"
+        - "I'm not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case / motivation
+      description: |
+        Who benefits from this? Is there a concrete project, integration, or workflow that needs
+        this feature? Real-world context helps us prioritise.
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context, mockups, links to related discussions, or prior art here.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: |
+        By submitting this request, you agree to follow the project's
+        [Code of Conduct](https://github.com/a-novel/.github/blob/master/CODE_OF_CONDUCT.md).
+      options:
+        - label: I agree to follow this project's Code of Conduct.
+          required: true
+        - label: I have searched existing issues and confirmed this is not a duplicate.
+          required: true
+        - label: I have checked the roadmap and confirmed this is not already planned.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,89 @@
+<!--
+Thanks for opening a pull request against an a-novel repository!
+
+Before you submit, please make sure:
+  - The PR title follows Conventional Commits: <type>(<scope>): <description>
+    Examples: feat(dao): add key revoke endpoint
+              fix(handlers): return 404 instead of 500 on missing key
+              chore(deps): bump golib to v1.4.2
+  - The branch name follows the same vocabulary: <type>/<scope>/<short-description>
+  - You have read the contributing guide (../CONTRIBUTING.md) and the
+    Code of Conduct (../CODE_OF_CONDUCT.md).
+
+You can delete this comment block once your PR is ready.
+-->
+
+## Summary
+
+<!-- 1–3 short bullets describing WHAT changed and WHY. Skip the "how" — reviewers will read the diff. -->
+
+-
+-
+
+## Linked issues
+
+<!-- Use "Closes #123" to auto-close on merge, or "Refs #123" to link without closing.
+     If there is no related issue, write "None" and briefly explain the motivation. -->
+
+Closes #
+
+## Type of change
+
+<!-- Tick all that apply. -->
+
+- [ ] `feat` — new capability
+- [ ] `fix` — bug fix
+- [ ] `refactor` — restructuring without behaviour change
+- [ ] `perf` — performance improvement
+- [ ] `test` — tests only
+- [ ] `docs` — documentation only
+- [ ] `chore` — maintenance, dependencies, build, etc.
+- [ ] `ci` — CI/CD pipeline only
+- [ ] `revert` — revert of a previous commit
+
+## Breaking changes
+
+<!-- If this PR introduces a breaking change, add `!` to the commit type (e.g. `feat(proto)!: …`)
+     AND a `BREAKING CHANGE:` footer in the commit body. Describe the break and the migration
+     path below. -->
+
+- [ ] This PR contains **no** breaking changes.
+- [ ] This PR contains breaking changes (described below).
+
+<!-- If breaking, describe:
+       - what breaks
+       - which consumers are affected
+       - the migration steps users must take
+-->
+
+## Test plan
+
+<!-- How did you verify the change? Tick every check that applies, and add any manual steps
+     reviewers should run locally. Replace `make …` with the equivalent command for the repo
+     if it uses a different runner (pnpm, just, etc.). -->
+
+- [ ] Unit tests pass locally (`make test-unit` / `pnpm test` / equivalent)
+- [ ] Integration tests pass locally where applicable
+- [ ] Linters and formatters pass (`make lint` / `pnpm lint` / equivalent)
+- [ ] Manually verified in a local dev environment (describe steps below)
+
+<!-- Manual verification steps:
+
+1.
+2.
+-->
+
+## Screenshots / recordings
+
+<!-- For UI changes, paste before/after screenshots or a short recording. Otherwise, delete this
+     section. -->
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits and is under 70 characters
+- [ ] Commits are split into logical units (one DAO file + its test = one commit, etc.)
+- [ ] No secrets, credentials, or `.env` files are committed
+- [ ] Documentation (READMEs, doc comments, OpenAPI, proto comments) is updated where relevant
+- [ ] Generated artifacts (proto bindings, mocks, OpenAPI clients) are committed alongside the
+      source change that required them
+- [ ] CI is green (or the remaining failures are unrelated and explained below)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,115 @@
+# Security Policy
+
+This document outlines the security policy for the [`a-novel`](https://github.com/a-novel)
+organization and **applies to every repository under it**, unless an individual repository
+publishes its own `SECURITY.md` that supersedes this one.
+
+- [Reporting a Vulnerability](#reporting-a-vulnerability)
+- [What to Include in a Report](#what-to-include-in-a-report)
+- [Supported Versions](#supported-versions)
+- [Scope](#scope)
+- [Out of Scope](#out-of-scope)
+- [Disclosure Policy](#disclosure-policy)
+- [Recognition](#recognition)
+- [Comments on This Policy](#comments-on-this-policy)
+
+## Reporting a Vulnerability
+
+The `A-Novel` team takes all security reports seriously. Thank you for helping us keep our users
+and contributors safe — we appreciate your time and your responsible disclosure.
+
+**Please do not open public GitHub issues, pull requests, or discussions for security reports.**
+Public reports give attackers a head start before a fix is ready.
+
+You have two preferred reporting channels:
+
+1. **GitHub private vulnerability reporting (recommended).** Navigate to the affected repository
+   on GitHub, open the **Security** tab, click **Report a vulnerability**, and submit a private
+   advisory. This keeps the report scoped to the affected repository and gives us a private
+   workspace to coordinate the fix with you.
+2. **Email.** Write to the lead maintainer at
+   **<geoffroy.vincent@agorastoryverse.com>**. Use a clear subject line that starts with
+   `[security]` so the report is not lost in normal traffic.
+
+You should receive an acknowledgement within **48 hours**, and a more detailed response within
+**a further 48 hours** indicating the next steps. From there we will keep you informed of progress
+toward a fix and may ask follow-up questions.
+
+If the vulnerability lives in a **third-party dependency** rather than our own code, please report
+it to that dependency's maintainers and let us know the upstream report so we can track the fix.
+
+## What to Include in a Report
+
+A useful report typically contains:
+
+- The affected repository (and, if known, the affected version, commit SHA, or release tag).
+- A description of the vulnerability and the impact you believe it has.
+- Reproduction steps, a proof-of-concept, or a minimal example.
+- Any relevant logs, screenshots, or network traces — **with any secrets redacted**.
+- Your assessment of severity (CVSS or informal) if you have one.
+- Whether you would like to be credited publicly, and under what name.
+
+Do not perform testing that could degrade service for other users (denial-of-service, mass account
+creation, data destruction). If you are unsure whether a test is safe, **ask first**.
+
+## Supported Versions
+
+Unless an individual repository's `SECURITY.md` says otherwise, only the **latest released
+version** of each package or service is supported with security fixes. For services and
+applications, "latest released" means the current `master` branch and the most recent published
+container image or deployment. For libraries, it means the most recent Git tag on the default
+branch.
+
+Older versions may receive a fix at the maintainers' discretion when the fix is trivial to
+backport, but this is not guaranteed. If you depend on an older version in production, please
+plan to upgrade.
+
+## Scope
+
+The following are in scope for this policy:
+
+- All source code in repositories under the [`a-novel`](https://github.com/a-novel) and
+  [`a-novel-kit`](https://github.com/a-novel-kit) GitHub organizations.
+- Published artifacts produced by those repositories — Go modules, npm packages, container
+  images, and any other release artifact distributed under either organization.
+- Infrastructure that is owned and operated by the `A-Novel` team and serves project users
+  directly.
+
+## Out of Scope
+
+The following are **out of scope** for this policy. Please do not file security reports for them
+here — report them to the responsible party instead.
+
+- Vulnerabilities in third-party services that we use but do not operate (e.g., GitHub itself,
+  cloud providers, SaaS dependencies).
+- Vulnerabilities in third-party libraries that we depend on — report those to the library's
+  maintainers. We will track and apply upstream fixes once they are released.
+- Social-engineering attacks targeting individual contributors, employees, or community members.
+- Findings from automated scanners with no demonstrated impact, missing best-practice headers
+  with no exploit path, or theoretical issues without a working proof-of-concept.
+
+## Disclosure Policy
+
+When a valid security report is received, a primary handler will be assigned to coordinate the
+response. The handler will:
+
+1. Confirm the problem and determine the set of affected versions and repositories.
+2. Audit related code for similar issues that may share the root cause.
+3. Prepare fixes for all releases still under support and merge them privately.
+4. Publish a coordinated release containing the fix.
+5. Publish a public security advisory (and, where applicable, a CVE) crediting the reporter.
+
+We aim to release a fix within **90 days** of the initial report for most issues, and faster for
+critical ones. We will coordinate the public disclosure date with the reporter and try not to
+disclose until a fix is available.
+
+## Recognition
+
+If you would like to be credited in the public advisory, tell us in the initial report and let us
+know the name (and optional link) you would like us to use. Anonymous reporters are equally
+welcome.
+
+## Comments on This Policy
+
+If you have suggestions on how this policy could be improved, please open a pull request against
+this file in the [`.github`](https://github.com/a-novel/.github) repository.


### PR DESCRIPTION
## Summary

- Adds an org-wide `SECURITY.md` at the repo root that every repository under the `a-novel` (and, by intent, `a-novel-kit`) organization will inherit unless it ships its own.
- Adds a default pull-request template under `.github/PULL_REQUEST_TEMPLATE.md`, aligned with the Conventional Commits convention used across the org and generic enough to cover services, libraries and the frontend.
- Adds two YAML issue forms (`bug_report.yml`, `feature_request.yml`) and a `config.yml` that disables blank issues and routes questions to Discord and security reports to the private channel.

## Linked issues

None — community-health bootstrap.

## Why

The previous per-repo `SECURITY.md` files had drifted (some still pointed at the deprecated `agoradesecrivains.com` address while others used the current `agorastoryverse.com` one). Centralising at the org level means the policy lives in one place; once the per-repo files are removed, GitHub will fall back to this file silently for every sub-repo. Same logic for PR/issue templates: today every repo that wants a template has to maintain its own, and they drift; an org-level default makes the funnel uniform.

## What is in the policy

- `SECURITY.md`: private vulnerability reporting via GitHub advisories (preferred) or email, 48 h ack / 48 h response, 90 d disclosure target, in/out of scope spelled out, optional reporter credit.
- `PULL_REQUEST_TEMPLATE.md`: Conventional-Commits reminder, summary, linked issues, type-of-change checkboxes, breaking-change section, test plan, and a checklist that mirrors the rules in `.claude/skills/git-conventions` (logical-unit commits, no secrets, generated artifacts bundled with their source change).
- `ISSUE_TEMPLATE/bug_report.yml`: affected repo, version, reproduction, expected, actual — all required; environment and logs optional; `render: shell` on log/output fields so tracebacks don't get mangled by Markdown.
- `ISSUE_TEMPLATE/feature_request.yml`: problem statement, proposed solution, alternatives, breaking-change dropdown, use case.
- `ISSUE_TEMPLATE/config.yml`: `blank_issues_enabled: false` plus contact links to the security policy, Discord, and the Code of Conduct.

## Breaking changes

None for this repository. Once published, repositories with their own `SECURITY.md`, `PULL_REQUEST_TEMPLATE.md` or `ISSUE_TEMPLATE/` will continue to use their local versions — the org-level files are only fallbacks. Removing those per-repo overrides in follow-up PRs is what activates the new defaults.

## Test plan

GitHub renders these files at the org level only after merge to \`master\`, so most verification is post-merge:

- [ ] After merge, https://github.com/a-novel/.github/security/policy shows the new SECURITY.md.
- [ ] On any sub-repo without a local override, the "Security" tab points at this policy.
- [ ] On any sub-repo without local templates, "New issue" shows the Bug / Feature picker plus the contact links from `config.yml`, and "New pull request" pre-fills the PR template.
- [ ] YAML issue forms validate (no parser error in the GitHub UI). The repo already runs `prettier --check` against YAML; CI on this PR will catch any formatting issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)