### PR TITLE
feat(bot-comment): batch dispatch — many comments in one run

### DIFF
--- a/.github/workflows/bot-comment.yaml
+++ b/.github/workflows/bot-comment.yaml
@@ -4,15 +4,19 @@
 # comment as this org's App bot. They trigger it (workflow_dispatch, via
 # `a-novel core bot-comment`) with their OWN gh token; the App private
 # key never leaves this org's Actions secrets and never touches a dev
-# machine. This job only ever posts a comment. The token it mints is
+# machine. This job only ever posts comments. The token it mints is
 # scoped to this single repo with issues + pull_requests write and
 # nothing else — no `contents`, no `administration` — so pushing,
 # merging, releasing and settings changes are impossible by permission.
 # Authoring or editing a PR/issue rides on those same writes the bot
 # needs to comment, so that is prevented not by the token but by what
 # this job does (comment, then exit) — on a workflow that lives on the
-# protected default branch. Net: a compromised trigger can ask for a
-# comment and nothing more.
+# protected default branch. Net: a compromised trigger can ask for
+# comments and nothing more.
+#
+# A run posts ONE comment (the single inputs) OR a batch of them (the
+# `comments` JSON array) — every comment in a batch targets this one
+# scoped repo, since the token is repo-scoped by design.
 #
 # ONE COPY PER ORG. Org secrets do not cross org boundaries, so each org
 # (a-novel, a-novel-kit) hosts its own copy of this file in a repo it
@@ -34,31 +38,41 @@ on:
       repo:
         description: "Target repo name within this org (no owner/ prefix)"
         required: true
-      number:
-        # Issues and PRs share one number sequence per repo, so a number
-        # is never ambiguous — it is an issue XOR a PR.
-        description: "PR or issue number"
-        required: true
-      body:
-        description: "Markdown comment body"
-        required: true
-      reply_to:
-        description: "Inline review-comment ID to reply to (empty = top-level comment)"
-        required: false
-        default: ""
       nonce:
         description: "Client-generated id, for run correlation + idempotency"
         required: true
+      # Single-comment form (back-compat). Used only when `comments` is empty.
+      number:
+        # Issues and PRs share one number sequence per repo, so a number
+        # is never ambiguous — it is an issue XOR a PR.
+        description: "PR or issue number (single-comment form)"
+        required: false
+        default: ""
+      body:
+        description: "Markdown comment body (single-comment form)"
+        required: false
+        default: ""
+      reply_to:
+        description: "Inline review-comment ID to reply to (single form; empty = top-level)"
+        required: false
+        default: ""
+      # Batch form: a JSON array of {number, body, reply_to?}. When non-empty
+      # it supersedes the single inputs, and every item is posted in this one
+      # run, each with its own per-index idempotency marker.
+      comments:
+        description: "JSON array of {number, body, reply_to?} (batch form)"
+        required: false
+        default: ""
 
 # The run-name carries the nonce so `a-novel core bot-comment` can find
 # the run it just dispatched and watch it synchronously.
-run-name: "bot-comment ${{ github.repository_owner }}/${{ inputs.repo }}#${{ inputs.number }} (${{ inputs.nonce }})"
+run-name: "bot-comment ${{ github.repository_owner }}/${{ inputs.repo }} (${{ inputs.nonce }})"
 
 # Serialize same-nonce dispatches so the idempotency check in the post
 # step cannot race two runs into a double-post. Distinct dispatches carry
 # distinct nonces, so this never serializes unrelated comments.
 concurrency:
-  group: bot-comment-${{ inputs.repo }}-${{ inputs.number }}-${{ inputs.nonce }}
+  group: bot-comment-${{ inputs.repo }}-${{ inputs.nonce }}
   cancel-in-progress: false
 
 # The default GITHUB_TOKEN gets nothing; every write below uses the
@@ -74,12 +88,16 @@ jobs:
       - name: Validate inputs
         env:
           REPO: ${{ inputs.repo }}
-          NUMBER: ${{ inputs.number }}
-          BODY: ${{ inputs.body }}
-          REPLY_TO: ${{ inputs.reply_to }}
           NONCE: ${{ inputs.nonce }}
+          COMMENTS: ${{ inputs.comments }}
         run: |
           set -euo pipefail
+          # Validate only what the GitHub API can't report meaningfully: the
+          # token-scope input, the nonce format, and the batch shape. Per-comment
+          # number / body / reply_to errors are left to the API at post time, so
+          # our rules can't drift from GitHub's; a malformed batch may partially
+          # post, which the per-item idempotency markers make recoverable on a
+          # re-dispatch.
           if [ -z "$REPO" ]; then
             echo "::error::repo is empty"
             exit 1
@@ -90,35 +108,18 @@ jobs:
               exit 1
               ;;
           esac
-          # Positive integer, no leading zero (rejects '', '0', '007', non-digits).
-          case "$NUMBER" in
-            '' | 0* | *[!0-9]*)
-              echo "::error::number '$NUMBER' must be a positive integer"
-              exit 1
-              ;;
-          esac
-          if [ -n "$REPLY_TO" ]; then
-            case "$REPLY_TO" in
-              0* | *[!0-9]*)
-                echo "::error::reply_to '$REPLY_TO' must be a positive integer"
-                exit 1
-                ;;
-            esac
-          fi
-          # nonce is lowercase hex (matches the CLI's hex.EncodeToString).
+          # nonce is lowercase hex (matches the CLI's hex.EncodeToString); the
+          # API never sees it — it is marker / run-name text the CLI correlates on.
           case "$NONCE" in
             '' | *[!0-9a-f]*)
               echo "::error::nonce '$NONCE' must be lowercase hex"
               exit 1
               ;;
           esac
-          if [ -z "$BODY" ]; then
-            echo "::error::body is empty"
-            exit 1
-          fi
-          # GitHub caps a comment at 65536 chars; stay safely under.
-          if [ "${#BODY}" -gt 60000 ]; then
-            echo "::error::body is ${#BODY} chars (max 60000)"
+          # comments, when present, must be a non-empty JSON array — otherwise the
+          # post loop's jq fails cryptically mid-run.
+          if [ -n "$COMMENTS" ] && ! printf '%s' "$COMMENTS" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+            echo "::error::comments must be a non-empty JSON array"
             exit 1
           fi
 
@@ -138,41 +139,61 @@ jobs:
           permission-issues: write
           permission-pull-requests: write
 
-      - name: Post comment
+      - name: Post comments
         env:
           GH_TOKEN: ${{ steps.app.outputs.token }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ inputs.repo }}
+          NONCE: ${{ inputs.nonce }}
           NUMBER: ${{ inputs.number }}
           BODY: ${{ inputs.body }}
           REPLY_TO: ${{ inputs.reply_to }}
-          NONCE: ${{ inputs.nonce }}
+          COMMENTS: ${{ inputs.comments }}
         run: |
           set -euo pipefail
           slug="${OWNER}/${REPO}"
-          marker="<!-- bot-comment:${NONCE} -->"
-          full_body="${BODY}"$'\n\n'"${marker}"
 
-          # reply_to set  -> reply inside a PR inline review thread (PR only).
-          # reply_to empty -> a top-level comment; the issues endpoint serves
-          #                   both PRs (a PR is an issue) and plain issues.
-          if [ -n "$REPLY_TO" ]; then
-            list_url="repos/${slug}/pulls/${NUMBER}/comments"
-            post_url="repos/${slug}/pulls/${NUMBER}/comments/${REPLY_TO}/replies"
+          # Normalize to a JSON array of {number, body, reply_to}. The single
+          # form is a one-item batch, so the loop below is the only post path.
+          if [ -n "$COMMENTS" ]; then
+            items="$COMMENTS"
           else
-            list_url="repos/${slug}/issues/${NUMBER}/comments"
-            post_url="repos/${slug}/issues/${NUMBER}/comments"
+            items=$(jq -cn --arg n "$NUMBER" --arg b "$BODY" --arg r "$REPLY_TO" \
+              '[{number: $n, body: $b, reply_to: $r}]')
           fi
 
-          # Idempotency: if a comment already carries this nonce marker, a
-          # previous dispatch posted it — do not post again.
-          existing=$(gh api "$list_url" --paginate \
-            --jq "[.[] | select(.body | contains(\"${marker}\")) | .html_url] | .[0] // empty")
-          existing=$(printf '%s\n' "$existing" | head -n1)
-          if [ -n "$existing" ]; then
-            echo "already posted (idempotent): $existing" | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
+          # Post each item. The marker carries nonce:index, so a retried run
+          # is idempotent per comment (skips what already landed) and never
+          # double-posts. Indices are stable: the same array yields the same
+          # markers on a retry.
+          idx=0
+          while IFS= read -r item; do
+            number=$(printf '%s' "$item" | jq -r '.number')
+            body=$(printf '%s' "$item" | jq -r '.body')
+            reply_to=$(printf '%s' "$item" | jq -r '.reply_to // ""')
+            marker="<!-- bot-comment:${NONCE}:${idx} -->"
+            full_body="${body}"$'\n\n'"${marker}"
 
-          url=$(gh api --method POST "$post_url" -f body="$full_body" --jq .html_url)
-          echo "posted: $url" | tee -a "$GITHUB_STEP_SUMMARY"
+            # reply_to set  -> reply inside a PR inline review thread (PR only).
+            # reply_to empty -> a top-level comment; the issues endpoint serves
+            #                   both PRs (a PR is an issue) and plain issues.
+            if [ -n "$reply_to" ]; then
+              list_url="repos/${slug}/pulls/${number}/comments"
+              post_url="repos/${slug}/pulls/${number}/comments/${reply_to}/replies"
+            else
+              list_url="repos/${slug}/issues/${number}/comments"
+              post_url="repos/${slug}/issues/${number}/comments"
+            fi
+
+            # Idempotency: if a comment already carries this nonce:index
+            # marker, a previous run posted it — skip.
+            existing=$(gh api "$list_url" --paginate \
+              --jq "[.[] | select(.body | contains(\"${marker}\")) | .html_url] | .[0] // empty")
+            if [ -n "$existing" ]; then
+              echo "already posted (idempotent): $existing" | tee -a "$GITHUB_STEP_SUMMARY"
+            else
+              url=$(gh api --method POST "$post_url" -f body="$full_body" --jq .html_url)
+              echo "posted: $url" | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
+            idx=$((idx + 1))
+          done < <(printf '%s' "$items" | jq -c '.[]')


### PR DESCRIPTION
The `a-novel` org's copy of the batch-dispatcher change — **byte-identical** to `a-novel-kit/stack#111`, where it was reviewed and **proven on the runner** (batch + idempotency + single-form live-tests). The two org dispatchers must stay in lockstep, so this carries the same content verbatim, including the validation decision (trim per-field checks, lean on the API; keep repo / nonce / comments-shape).

Merge alongside `a-novel-kit/stack#111` — both dispatchers should be live before the CLI batch path (`a-novel-kit/stack#109`) ships.

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)