### PR TITLE
ci: migrate bot-token auth from app_id to client_id

### DIFF
--- a/.github/workflows/bot-comment.yaml
+++ b/.github/workflows/bot-comment.yaml
@@ -27,8 +27,8 @@
 # Secret (one org-level secret per org, same name in each):
 #   AGENT_BOT_PRIVATE_KEY  this org's bot App private key, PEM
 # (a-novel -> anovelbot-agent, a-novel-kit -> anovelkitbot-agent.)
-# App IDs are public (visible in any App settings URL), so they are
-# inlined below.
+# Variable (one org-level variable per org, same name in each):
+#   AGENT_BOT_CLIENT_ID  this org's bot App client id (public).
 
 name: bot-comment
 
@@ -132,7 +132,7 @@ jobs:
         id: app
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ github.repository_owner == 'a-novel' && '3549319' || '3549379' }}
+          client-id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           private-key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ inputs.repo }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,4 +18,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -23,4 +23,4 @@ jobs:
           allowed_commands: '["^go mod tidy && go generate .*", "^go mod tidy && go tool .*", "^go get -u .*", "^pnpm i --frozen-lockfile$"]'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
-          app_id: ${{ vars.DEPENDENCY_BOT_ID }}
+          client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}


### PR DESCRIPTION
## Summary

Part of **a-novel-kit/workflows#191** Stage 2. Migrates this repo's bot-token usage from the deprecated `app_id` to `client_id`, clearing the `'app-id' deprecated — use 'client-id'` warning.

## Changed

- `main.yaml` — `node-actions/lint-node`: `DEPENDENCY_BOT_ID` → `DEPENDENCY_BOT_CLIENT_ID`
- `renovate.yaml` — `generic-actions/renovate`: `DEPENDENCY_BOT_ID` → `DEPENDENCY_BOT_CLIENT_ID`
- `bot-comment.yaml` — realigned to the **canonical** shared copy (the file mandates "keep the two copies identical"): mint via `client-id: ${{ vars.AGENT_BOT_CLIENT_ID }}` instead of the inlined numeric `app-id` conditional. Now byte-identical to `a-novel-kit/stack`'s copy.

The `*_BOT_CLIENT_ID` org vars already exist.

## Breaking changes

None — `app_id`/`app-id` still works on the shared actions (removed later in #191 Stage 3).

## Test plan

- [x] `pnpm run lint:stylecheck` (prettier) passes repo-wide
- [ ] CI `lint-node` (this PR) passes via the `client_id` path