### PR TITLE
feat(reconcile): flip the partial-landing sweep live (detect_dry_run=false) — enforce step 2/3

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -19,5 +19,8 @@ jobs:
     with:
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+      # Enforce the partial-landing detector: the sweep posts epic-freeze check-runs (success on
+      # healthy + standalone heads, failure on a partial landing) instead of only logging.
+      detect_dry_run: "false"
     secrets:
       private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
**Enforce-flip step 2 of 3** for epic-freeze (a-novel-kit/.github#52). The sweep half — pairs with the per-PR poster flip (stack repocfg) and precedes the checks.yaml require.

Adds `detect_dry_run: "false"` so the scheduled sweep posts `epic-freeze` check-runs instead of only logging: **success** on healthy + standalone heads (the standalone backstop = universal satisfiability floor), **failure** on a partial landing. This is what primes every open head green before epic-freeze is required.

Verified `detect_dry_run` is supported at the pinned reconcile-board tag. Merge alongside the poster flip; then wait one live sweep before the checks.yaml require step.