### PR TITLE
ci: add per-org watchdog + token-expiry schedule callers

### DIFF
--- a/.github/workflows/token-expiry.yaml
+++ b/.github/workflows/token-expiry.yaml
@@ -1,0 +1,39 @@
+# Per-org daily fine-grained-PAT expiry digest → the token-expiry Discord channel. Thin scheduled
+# caller of the shared reusable workflow in a-novel-kit/workflows; the enumeration + digest live
+# there, this owns only the schedule + concurrency. The App token is auto-scoped to THIS org, so each
+# org's caller sweeps its own PATs.
+name: token-expiry
+
+on:
+  schedule:
+    - cron: "0 8 * * *" # daily 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      test_run:
+        description: "Test run: post to token-tracker for EVERY PAT (admin only), ignoring the milestone policy."
+        type: boolean
+        default: false
+
+# One sweep at a time.
+concurrency:
+  group: token-expiry
+  cancel-in-progress: false
+
+jobs:
+  token-expiry:
+    # TODO: bump to the release tag (e.g. @v1.17.0) once a-novel-kit/workflows ships this reusable
+    # workflow; pinned to the feature branch for pre-release testing.
+    uses: a-novel-kit/workflows/.github/workflows/token-expiry.yaml@feat/watchdog/bypass-audit
+    with:
+      client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+      # Start dry-run: enumerate + log the pings that WOULD fire, no Discord post, until a cycle is
+      # seen. Flip to "false" to arm the real daily pings (watchdog / reconcile-board staged-rollout
+      # convention). A UI test_run always posts for real regardless of this.
+      dry_run: "true"
+      # UI-only: post for every PAT, admin-only, ignoring the milestone policy — an end-to-end drill.
+      test_run: ${{ inputs.test_run || false }}
+    secrets:
+      private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+      webhook: ${{ secrets.TOKEN_EXPIRY_WEBHOOK }}
+      # All pings go to this admin for now; per-owner pinging arrives with the Bitwarden resolver (#104).
+      default_mention: ${{ secrets.TOKEN_EXPIRY_ADMIN }}

--- a/.github/workflows/token-expiry.yaml
+++ b/.github/workflows/token-expiry.yaml
@@ -21,9 +21,7 @@ concurrency:
 
 jobs:
   token-expiry:
-    # TODO: bump to the release tag (e.g. @v1.17.0) once a-novel-kit/workflows ships this reusable
-    # workflow; pinned to the feature branch for pre-release testing.
-    uses: a-novel-kit/workflows/.github/workflows/token-expiry.yaml@feat/watchdog/bypass-audit
+    uses: a-novel-kit/workflows/.github/workflows/token-expiry.yaml@v1.17.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       # Start dry-run: enumerate + log the pings that WOULD fire, no Discord post, until a cycle is

--- a/.github/workflows/watchdog.yaml
+++ b/.github/workflows/watchdog.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   watchdog:
-    uses: a-novel-kit/workflows/.github/workflows/watchdog.yaml@v1.16.1
+    uses: a-novel-kit/workflows/.github/workflows/watchdog.yaml@v1.17.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}

--- a/.github/workflows/watchdog.yaml
+++ b/.github/workflows/watchdog.yaml
@@ -1,0 +1,32 @@
+# Per-org staleness watchdog — a thin scheduled caller of the shared reusable workflow in
+# a-novel-kit/workflows. The detection (stale required checks, stuck hotfix runs, and the fail-safe
+# heartbeat) lives there; this file owns only the schedule, the concurrency, and the per-org board id.
+name: watchdog
+
+on:
+  schedule:
+    - cron: "*/30 * * * *" # the backstop cadence (stale-check threshold is 30m)
+  workflow_dispatch:
+
+# One watchdog at a time.
+concurrency:
+  group: watchdog
+  cancel-in-progress: false
+
+jobs:
+  watchdog:
+    uses: a-novel-kit/workflows/.github/workflows/watchdog.yaml@v1.16.1
+    with:
+      client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
+      project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
+      # SEV1/SEV2 @mention for the escalation ticket + the Discord page. Discord pings a role only in
+      # the `<@&ROLE_ID>` form, so SEV1_MENTION must be that wrapped value, not a bare id.
+      mention: ${{ vars.SEV1_MENTION }}
+      # Heartbeat: page SEV1 if either scheduled fail-safe stops running (mutual dead-man's-switch).
+      heartbeat_workflows: "reconcile-board.yaml,watchdog.yaml"
+      # Start dry-run: detect + log, no real tickets/pages, until a cycle has been watched. Flip to
+      # "false" to arm it (like the reconcile-board detector's staged rollout).
+      dry_run: "true"
+    secrets:
+      private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}
+      push_webhook: ${{ secrets.ESCALATE_PUSH_WEBHOOK }}


### PR DESCRIPTION
## Summary

The two per-org scheduled **workflow callers** for the governance rollout, both starting in **dry-run**:
- `ci(watchdog)` — staleness watchdog caller (pins released `@v1.16.1`).
- `ci(token-expiry)` — daily org-wide fine-grained-PAT expiry tracker caller (pins `@feat/watchdog/bypass-audit`, pre-release).

## Merge gating (why this is a draft)

The **token-expiry** caller pins the reusable workflow's feature branch (a-novel-kit/workflows#286, unreleased). Before merge:
1. workflows#286 merges → cut a new `workflows` tag (e.g. `v1.17.0`).
2. Re-pin `token-expiry.yaml`: `@feat/watchdog/bypass-audit` → `@v1.17.0`.

The watchdog caller already pins a release and is independently ready.

## Behaviour
- Daily, `dry_run: "true"` (log only) until armed.
- token-expiry exposes a `workflow_dispatch` **Test run** (admin-only, every PAT, real post) — usable now from this branch.
- Schedules activate on merge to the default branch.

## Test plan
- [ ] Actions → token-expiry → Run workflow → branch `feat/watchdog/caller` → **Test run** → a digest lands in token-tracker (admin only)
- [ ] token-expiry dry-run scheduled run logs the PAT inventory without posting

🤖 Generated with [Claude Code](https://claude.com/claude-code)