### PR TITLE
docs(pr-template): nudge cross-repo close for planning issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,10 @@ You can delete this comment block once your PR is ready.
 ## Linked issues
 
 <!-- Use "Closes #123" to auto-close on merge, or "Refs #123" to link without closing.
-     If there is no related issue, write "None" and briefly explain the motivation. -->
+     If there is no related issue, write "None" and briefly explain the motivation.
+     Implementing a PLANNING issue (Epic/Feature/Task on the org board)? It lives in the org
+     .github repo — close it CROSS-REPO: "Closes a-novel/.github#123" (a bare "#123" links
+     nothing, so the issue never advances on the board). -->
 
 Closes #
 


### PR DESCRIPTION
Soft nudge for the board-lifecycle **cross-ref linkage discipline**. Planning issues live in this `.github` repo, but their PRs live in other repos where a bare `Closes #N` links nothing and the issue freezes on the board. Adds a one-line prompt to the `## Linked issues` comment to close them cross-repo (`Closes a-novel/.github#N`).

Companion to the skill doc (stack: `open-pull-request` 5.3) + the rule 3–6 automation (workflows#295). Comment-only — zero behavior change.