### PR TITLE
feat(board): take the reconcile sweep live (rollup + Applied archive)

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -22,5 +22,9 @@ jobs:
       # Enforce the partial-landing detector: the sweep posts epic-freeze check-runs (success on
       # healthy + standalone heads, failure on a partial landing) instead of only logging.
       detect_dry_run: "false"
+      # Board lifecycle live (validated dry 2026-07-07): roll each Epic/Initiative's Status up from
+      # its children, and archive+close resolved "Applied" meta work org-wide.
+      rollup_dry_run: "false"
+      archive_dry_run: "false"
     secrets:
       private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Flips `rollup_dry_run` + `archive_dry_run` → `false` so the reconcile sweep writes, after a clean dry-run validation (run 28839090778/95967): rollup would advance #53/#101 (0 wrong archival), and the Applied pass would archive+close #102. Same staged go-live as `detect_dry_run`. Completes the Stage-5.5 board consolidation deploy.