### PR TITLE
chore(reconcile-board): bump the sweep to v1.19.3 (activate closed→archive)

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   reconcile:
-    uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.19.2
+    uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.19.3
     with:
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}


### PR DESCRIPTION
Bumps `reconcile-board.yaml@v1.19.2 → @v1.19.3` — the release that adds the **closed→archive** pass (and, via the self-pin fix, runs every action at v1.19.3). After this, the sweep also clears done leaf planning issues (`closed ⟺ archived`). Last step of the Stage-5.5 board consolidation. → reconcile-board.yaml@v1.19.3