### PR TITLE
chore(reconcile): rehearse the activation-snapshot capture [DRAFT — two preconditions]

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -26,5 +26,11 @@ jobs:
       # its children, and archive+close resolved "Applied" meta work org-wide.
       rollup_dry_run: "false"
       archive_dry_run: "false"
+      # TEMPORARY — revert once the capture has been eyeballed on a live Epic.
+      # The sweep's merge-gate logs the activation snapshot it would capture and leaves the Epic body
+      # alone. While this is on, no snapshot ever freezes: a pending marker promotes on a later pass,
+      # and the sweep is usually the only thing that runs on a set that is ready and waiting. The
+      # Epic then lands on live label membership, so a member de-labelled mid-landing is lost.
+      regate_snapshot_dry_run: "true"
     secrets:
       private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
**Draft on purpose. Do not merge until both preconditions below hold, and open the revert alongside merging it.**

Turns the sweep's `merge-gate` capture into a rehearsal (`v1.22.0`, a-novel-kit/workflows#355). It logs the snapshot it would write and the set it judged, and leaves the Epic body alone. The `merge-gate` check-run is still posted, so nothing stops being gated.

## Precondition 1 — this caller must be on `v1.22.0` first

It currently pins `reconcile-board.yaml@v1.20.3`, which does not declare `regate_snapshot_dry_run`.

This is not the forgiving case. A composite action given an undeclared input logs `Unexpected input(s)` and carries on; a **reusable workflow** given one **fails the run**. Merging this before Renovate lands the `v1.22.0` bump would break the sweep on every 15-minute schedule, org-wide — and the sweep is what releases a held Epic member, so a stuck landing would have nothing to unstick it.

Renovate owns that bump. Wait for it, then rebase this.

## Precondition 2 — there must be something to rehearse against

The `regate` job is guarded by `if: needs.enumerate.outputs.epic_prs != '[]'`, and **no open pull request in either org currently carries an `epic:<N>` label**. Merging today produces a skipped job and an empty log.

The rehearsal wants a live Epic with its member PRs open and merge-ready — realistically the first cross-repo Epic off a-novel/.github#202.

## What to read in the run

Actions ▸ `reconcile-board` ▸ the `regate` matrix job for any member PR. A capture that is about to happen prints:

```
Epic #N: dry run — would write a "pending" activation snapshot. The Epic body is
untouched, so a repeated pass reports this same transition.
  set judged (3 member(s)):
    a-novel/service-narrative-engine#12
    a-novel/service-authentication#1150
    a-novel-kit/golib#380
  payload: {"status":"pending","at":"...","members":[...]}
```

**Judge the `set judged` block, not the payload.** The payload is mechanical; the set is the thing that becomes authoritative and is never rewritten. Every member repo of the Epic should appear exactly once, and nothing else should.

Wrong-looking outcomes and what each means:

| What you see | What it means |
| --- | --- |
| a member missing | the label search index is lagging, or that PR is not labeled `epic:<N>`. The two-phase capture exists for the first case — re-run the sweep and see whether it appears before you conclude anything |
| a repo you did not expect | something carries the `epic:<N>` label that should not. Fix the label, not the marker |
| `"pending"` on every re-run | correct. Nothing advances while rehearsing — that is stated in the log line |
| `"frozen"` | it read an existing `pending` marker that had aged past 120s. Fine, but means a real capture already happened before the rehearsal went on |
| the job skipped entirely | precondition 2 is unmet |

## Reverting

Revert as soon as you have read it. While this is on, no snapshot freezes: a `pending` marker promotes only on a later pass, and this sweep is usually the only thing that runs on a set that is ready and waiting. The Epic then lands on live label membership, and a member de-labeled mid-landing stops being remembered — which is the guarantee the snapshot exists to give.

🤖 Generated with [Claude Code](https://claude.com/claude-code)