### PR TITLE
chore(reconcile): re-pin the sweep to workflows v1.22.0

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   reconcile:
-    uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.20.3
+    uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.22.0
     with:
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}


### PR DESCRIPTION
Unblocks #212. Merge this first.

## Why ahead of Renovate

`v1.22.0` is what declares `regate_snapshot_dry_run` on the reusable sweep. A **reusable workflow handed an input it does not declare fails the run** — unlike a composite action, which logs `Unexpected input(s)` and carries on. So #212 cannot be merged while this caller points at `v1.20.3`: it would break `reconcile-board` on every 15-minute schedule, org-wide.

## Why only this one reference

**Seven of this repo's fourteen workflow files are regenerated** from `cli/internal/repocfg/templates/governance/` by `a-novel repo update`, so hand-editing them is reverted. `reconcile-board.yaml` is hand-owned, and it is the only file #212 needs, because `regate_snapshot_dry_run` is an input of the reusable *sweep*. The remaining thirteen references stay on `v1.20.3` for Renovate's group bump to move together.

## One transient hazard worth knowing

Those governance templates currently pin `@v1.20.2`, behind the `v1.20.3` this repo runs — so **`a-novel repo update` run right now would downgrade** `merge-gate.yaml`, `epic-freeze.yaml`, `derive-status.yaml`, `approve-pr.yaml`, `epic-rollback.yaml`, `release-train.yaml` and `auto-approve-dependabot.yaml`.

This is a lag, not a defect: the stack repo's `renovate.json` carries a custom regex manager over `cli/internal/repocfg/templates/governance/**` precisely because Renovate's built-in github-actions manager does not scan CLI templates, and its history shows it tracking every release (`v1.19.4 → v1.19.5 → v1.20.0 → v1.20.1 → v1.20.2`). Four tags were cut inside four hours today; it has not run since the first. It resolves on the next pass. Just do not run `a-novel repo update` before it does.

## Is the mixed tag safe in the meantime

For the rehearsal, yes. With `regate_snapshot_dry_run: "true"` the sweep's `merge-gate` writes nothing at all, so there is exactly one writer of any activation snapshot — each member repo's own event-driven gate, still on `v1.20.x`.

It should not outlive the rehearsal by long. Once the flag goes back off, a `v1.22.0` sweep and a `v1.20.x` member gate would both write the marker, and the older writer does not carry the wave boundary forward — it would drop the `since` the newer one wrote. That skew exists across the fleet regardless of this PR and is what Renovate's roll resolves; this just means there is no reason to sit in it.

## Verify

`reconcile-board` keeps running green on its schedule after merge, with the same five passes and no behavior change — `v1.22.0` adds one optional input and defaults it to the current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)