### PR TITLE
chore(reconcile): end the activation-snapshot rehearsal

### DIFF
--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -26,11 +26,5 @@ jobs:
       # its children, and archive+close resolved "Applied" meta work org-wide.
       rollup_dry_run: "false"
       archive_dry_run: "false"
-      # TEMPORARY — revert once the capture has been eyeballed on a live Epic.
-      # The sweep's merge-gate logs the activation snapshot it would capture and leaves the Epic body
-      # alone. While this is on, no snapshot ever freezes: a pending marker promotes on a later pass,
-      # and the sweep is usually the only thing that runs on a set that is ready and waiting. The
-      # Epic then lands on live label membership, so a member de-labelled mid-landing is lost.
-      regate_snapshot_dry_run: "true"
     secrets:
       private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Reverts the flag from #212. **This is the one that matters — while it is on, no activation snapshot ever freezes.**

## The rehearsal ran and passed

Scratch Epic a-novel/.github#215, two members in two repos, both approved and non-draft. The sweep's `merge-gate` reported:

```
Epic #215: dry run — would write a "frozen" activation snapshot. The Epic body is
untouched, so a repeated pass reports this same transition.
  set judged (2 member(s)):
    a-novel/service-json-keys#857
    a-novel/service-template#424
  payload: {"status":"frozen","at":"2026-07-22T17:25:38Z","members":[...]}
```

Correct on every count: both members, one per repo, canonical order, and nothing else.

**And it wrote nothing.** The marker on #215 was still `{"status":"pending","at":"2026-07-22T17:23:16Z",...}` afterwards — byte-identical to before the sweep, and never promoted to `frozen`.

## Two things the rehearsal established beyond the set

A first pass 59 seconds after the marker was written reported nothing at all: the decision was `skip`, because the 120-second stabilization window had not elapsed. The rehearsal only speaks when a real capture would happen, which is the correct shape and worth knowing before anyone reads an empty log as a fault.

The `pending` marker itself was written by the member repos' own event-driven gates, still on `v1.20.x` and unable to rehearse. That is the gap #322 closes: today the sweep can rehearse and the per-repo path cannot, so a rehearsal shows you the set without preventing the write.

## Why to merge promptly

A `pending` marker promotes to `frozen` only on a later pass, and this sweep is usually the only thing that runs on a set that is ready and waiting. Left on, an Epic lands on live label membership and a member de-labeled mid-landing stops being remembered.

Scratch Epic, both pull requests, both `epic:215` labels and both branches are torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)