### PR TITLE
chore(ci): replace GitGuardian + CodeQL with in-repo scanners on workflows v1.26.1

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.26.0
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.26.1
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.25.1
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.26.0
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       github.event.pull_request.user.login == vars.DEPENDENCY_BOT_LOGIN ||
       github.event.pull_request.user.login == vars.DEPENDABOT_SECURITY_LOGIN
-    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.26.0
+    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       dependency_bot_login: ${{ vars.DEPENDENCY_BOT_LOGIN }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -17,7 +17,7 @@ jobs:
     if: >-
       github.event.pull_request.user.login == vars.DEPENDENCY_BOT_LOGIN ||
       github.event.pull_request.user.login == vars.DEPENDABOT_SECURITY_LOGIN
-    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.25.1
+    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.26.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       dependency_bot_login: ${{ vars.DEPENDENCY_BOT_LOGIN }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -17,6 +17,9 @@ jobs:
     if: >-
       github.event.pull_request.user.login == vars.DEPENDENCY_BOT_LOGIN ||
       github.event.pull_request.user.login == vars.DEPENDABOT_SECURITY_LOGIN
+    # the callee mints a scoped App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
+    # the repository default.
+    permissions: {}
     uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -11,6 +11,6 @@ jobs:
       pull-requests: write
     if: ${{ github.event.pull_request.user.login != vars.DEPENDENCY_BOT_LOGIN }}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.25.1
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.26.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -11,6 +11,6 @@ jobs:
       pull-requests: write
     if: ${{ github.event.pull_request.user.login != vars.DEPENDENCY_BOT_LOGIN }}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.26.0
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.26.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.26.0
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.26.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.25.1
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.26.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -33,7 +33,7 @@ jobs:
     # a stray forward is sweep-only, so a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.25.1
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.26.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -33,7 +33,7 @@ jobs:
     # a stray forward is sweep-only, so a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.26.0
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.26.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -48,7 +48,7 @@ run-name: "⏮ ROLLBACK epic:#${{ inputs.epic_number }} requested by @${{ github
 
 jobs:
   rollback:
-    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.26.0
+    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.26.1
     with:
       epic_number: ${{ inputs.epic_number }}
       confirm: ${{ inputs.confirm }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -48,7 +48,7 @@ run-name: "⏮ ROLLBACK epic:#${{ inputs.epic_number }} requested by @${{ github
 
 jobs:
   rollback:
-    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.25.1
+    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.26.0
     with:
       epic_number: ${{ inputs.epic_number }}
       confirm: ${{ inputs.confirm }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -48,6 +48,10 @@ run-name: "⏮ ROLLBACK epic:#${{ inputs.epic_number }} requested by @${{ github
 
 jobs:
   rollback:
+    # matches the callee; the caller sets the ceiling, so it must not hand down
+    # the repository default.
+    permissions:
+      contents: read
     uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.26.1
     with:
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   hotfix:
-    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.25.1
+    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.26.0
     with:
       line: ${{ inputs.line }}
       fix_ref: ${{ inputs.fix_ref }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -46,6 +46,11 @@ concurrency:
 
 jobs:
   hotfix:
+    # the callee pushes the ephemeral branch and reads in-flight runs; the caller sets the ceiling, so it must not hand down
+    # the repository default.
+    permissions:
+      contents: write
+      actions: read
     uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.26.1
     with:
       line: ${{ inputs.line }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -46,7 +46,7 @@ concurrency:
 
 jobs:
   hotfix:
-    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.26.0
+    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.26.1
     with:
       line: ${{ inputs.line }}
       fix_ref: ${{ inputs.fix_ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,8 @@ jobs:
           persist-credentials: false
       - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.26.0
         with:
+          # Adopting over an existing backlog: report, do not gate. Flip to false once clean.
+          advisory: \"true\"
           ruleset: none
           # renovate: datasource=docker depName=semgrep/semgrep
           version: "1.171.0"
@@ -47,6 +49,8 @@ jobs:
           persist-credentials: false
       - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.26.0
         with:
+          # Adopting over an existing backlog: report, do not gate. Flip to false once clean.
+          advisory: \"true\"
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
           version: "8.30.1"
 
@@ -62,6 +66,8 @@ jobs:
           persist-credentials: false
       - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.26.0
         with:
+          # Adopting over an existing backlog: report, do not gate. Flip to false once clean.
+          advisory: \"true\"
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,8 +14,54 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.25.1
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.26.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}
+
+  # Structural conventions golangci-lint cannot express.
+  lint-semgrep:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.26.0
+        with:
+          ruleset: none
+          # renovate: datasource=docker depName=semgrep/semgrep
+          version: "1.171.0"
+
+  # Replaces GitGuardian, which gated on a hosted service: when it saturated,
+  # every PR in the fleet became unmergeable. This runs offline.
+  scan-secrets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.26.0
+        with:
+          # renovate: datasource=github-releases depName=gitleaks/gitleaks
+          version: "8.30.1"
+
+  # Replaces CodeQL's actions analysis: excessive-permissions is the class it
+  # reported as actions/missing-workflow-permissions.
+  lint-workflows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.26.0
+        with:
+          # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
+          version: "1.28.0"
+

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,4 +64,3 @@ jobs:
         with:
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
-

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.26.0
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.26.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.26.0
+      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.26.1
         with:
           ruleset: none
           # renovate: datasource=docker depName=semgrep/semgrep
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.26.0
+      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.26.1
         with:
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
           version: "8.30.1"
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.26.0
+      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.26.1
         with:
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,8 +31,6 @@ jobs:
           persist-credentials: false
       - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.26.0
         with:
-          # Adopting over an existing backlog: report, do not gate. Flip to false once clean.
-          advisory: \"true\"
           ruleset: none
           # renovate: datasource=docker depName=semgrep/semgrep
           version: "1.171.0"
@@ -49,8 +47,6 @@ jobs:
           persist-credentials: false
       - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.26.0
         with:
-          # Adopting over an existing backlog: report, do not gate. Flip to false once clean.
-          advisory: \"true\"
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
           version: "8.30.1"
 
@@ -66,8 +62,6 @@ jobs:
           persist-credentials: false
       - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.26.0
         with:
-          # Adopting over an existing backlog: report, do not gate. Flip to false once clean.
-          advisory: \"true\"
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
 

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   merge-gate:
-    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.26.0
+    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -31,6 +31,9 @@ on:
 
 jobs:
   merge-gate:
+    # the callee mints its own App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
+    # the repository default.
+    permissions: {}
     uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   merge-gate:
-    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.25.1
+    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.26.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   reconcile:
-    uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.25.1
+    uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.26.0
     with:
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   reconcile:
-    uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.26.0
+    uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.26.1
     with:
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/reconcile-board.yaml
+++ b/.github/workflows/reconcile-board.yaml
@@ -15,6 +15,9 @@ concurrency:
 
 jobs:
   reconcile:
+    # The callee mints its own App token and declares permissions: {}; the
+    # caller sets the ceiling, so it must not hand down the repo default.
+    permissions: {}
     uses: a-novel-kit/workflows/.github/workflows/reconcile-board.yaml@v1.26.1
     with:
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -35,7 +35,7 @@ run-name: "🚂 release train epic:#${{ inputs.epic_number }} requested by @${{ 
 
 jobs:
   release-train:
-    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.26.0
+    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -35,7 +35,7 @@ run-name: "🚂 release train epic:#${{ inputs.epic_number }} requested by @${{ 
 
 jobs:
   release-train:
-    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.25.1
+    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.26.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -35,6 +35,10 @@ run-name: "🚂 release train epic:#${{ inputs.epic_number }} requested by @${{ 
 
 jobs:
   release-train:
+    # matches the callee; the caller sets the ceiling, so it must not hand down
+    # the repository default.
+    permissions:
+      contents: read
     uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.25.1
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.26.0
         with:
           allowed_commands: '["^go mod tidy && go generate .*", "^go mod tidy && go tool .*", "^go get -u .*", "^pnpm i --frozen-lockfile$"]'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.26.0
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.26.1
         with:
           allowed_commands: '["^go mod tidy && go generate .*", "^go mod tidy && go tool .*", "^go get -u .*", "^pnpm i --frozen-lockfile$"]'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/token-expiry.yaml
+++ b/.github/workflows/token-expiry.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   token-expiry:
-    uses: a-novel-kit/workflows/.github/workflows/token-expiry.yaml@v1.26.0
+    uses: a-novel-kit/workflows/.github/workflows/token-expiry.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       # Start dry-run: enumerate + log the pings that WOULD fire, no Discord post, until a cycle is

--- a/.github/workflows/token-expiry.yaml
+++ b/.github/workflows/token-expiry.yaml
@@ -21,6 +21,9 @@ concurrency:
 
 jobs:
   token-expiry:
+    # The callee mints its own App token and declares permissions: {}; the
+    # caller sets the ceiling, so it must not hand down the repo default.
+    permissions: {}
     uses: a-novel-kit/workflows/.github/workflows/token-expiry.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/token-expiry.yaml
+++ b/.github/workflows/token-expiry.yaml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   token-expiry:
-    uses: a-novel-kit/workflows/.github/workflows/token-expiry.yaml@v1.25.1
+    uses: a-novel-kit/workflows/.github/workflows/token-expiry.yaml@v1.26.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       # Start dry-run: enumerate + log the pings that WOULD fire, no Discord post, until a cycle is

--- a/.github/workflows/watchdog.yaml
+++ b/.github/workflows/watchdog.yaml
@@ -15,6 +15,9 @@ concurrency:
 
 jobs:
   watchdog:
+    # The callee mints its own App token and declares permissions: {}; the
+    # caller sets the ceiling, so it must not hand down the repo default.
+    permissions: {}
     uses: a-novel-kit/workflows/.github/workflows/watchdog.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/watchdog.yaml
+++ b/.github/workflows/watchdog.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   watchdog:
-    uses: a-novel-kit/workflows/.github/workflows/watchdog.yaml@v1.26.0
+    uses: a-novel-kit/workflows/.github/workflows/watchdog.yaml@v1.26.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}

--- a/.github/workflows/watchdog.yaml
+++ b/.github/workflows/watchdog.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   watchdog:
-    uses: a-novel-kit/workflows/.github/workflows/watchdog.yaml@v1.25.1
+    uses: a-novel-kit/workflows/.github/workflows/watchdog.yaml@v1.26.0
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       project_id: ${{ github.repository_owner == 'a-novel' && 'PVT_kwDOB9MxdM4BMh8r' || 'PVT_kwDOCy-nAM4BbtKH' }}


### PR DESCRIPTION
Fleet-wide CI upgrade to `a-novel-kit/workflows` **v1.26.1**, done in one pass so no second sweep is
needed.

## Why now

v1.26.x makes four inputs **required**. Without this change, the first Renovate bump breaks CI here —
so this lands ahead of it.

## What changed

| | |
| --- | --- |
| **Added** | `lint-semgrep`, `scan-secrets`, `lint-workflows` |
| **Removed** | `codeql.yml`, the GitGuardian workflow |
| **Pinned** | shellcheck, hadolint, a-novel CLI — annotated so Renovate bumps each per repo |
| **Bumped** | every `a-novel-kit/workflows` ref to v1.26.1 |

### Replacing GitGuardian

`scan-secrets` runs gitleaks in CI. GitGuardian was a **hosted service on the merge path**: when it
saturated at roughly one scan a minute against a fleet opening 144 PRs a day, every affected PR
became permanently unmergeable, because a required check that never arrives has no timeout. The
replacement is offline and finishes in milliseconds.

The rule this leaves behind: *a required status check must not depend on a third-party network
service.*

### Retiring CodeQL

Its entire output across the fleet was `actions/missing-workflow-permissions` (x5 per repo, now
covered by `lint-workflows`) plus `go/log-injection` (x3, service-authentication only).

**service-authentication carries those 3 open alerts** — triage them before relying on this. Go
taint analysis is not replaced: Semgrep OSS cannot do cross-file dataflow.

### Pins are annotated, not just pinned

```yaml
# renovate: datasource=github-releases depName=gitleaks/gitleaks
version: "8.30.1"
```

No built-in Renovate manager reads a version inside a `with:` block. v1.26.0 added a custom manager
that keys off exactly this comment, so each repo bumps on its own cadence instead of waiting for a
workflows release.

## What the new checks caught

These are real defects the sweep surfaced and this PR fixes in place, rather than deferring:

- **Unrecorded errors** — error paths that returned without `otel.ReportError`, so the span closed
  green on a failure.
- **Untraced functions** — `agora-must-open-span` requires a span in every `internal/` function
  taking a `context.Context`. Taking a context *is* the criterion; there are no exemptions, and a
  function that should not be traced is one that does not take a context.
- **Identity-suppression** — a `select` that silently swallowed its own error.
- **snake_case config filenames**, a `go install …@latest` on the release path, an unpinned
  shellcheck, and an `npm install -g pnpm` that ignored `packageManager`.

Two sites carry a `nosemgrep` with the reason stated at the site: a mutex-guarded cache (the rule
forbids mutation because these types are shared *unsynchronised* — this one is not), and a
dependency interface whose method name belongs to a published client, not to us.

## Merging

`GitGuardian Security Checks` is still in each ruleset's required list, so these will not auto-merge.
That is expected — **force-merge**, then `a-novel repo update` reconciles the rulesets from the
statically-derived set.

## Test plan

- [x] `lint-semgrep`, `scan-secrets`, `lint-workflows` pass
- [x] `lint-go` / `lint-node` and the existing jobs pass
- [x] verified locally with the shipped v1.26.1 rules before pushing
