### PR TITLE
ci(ci): cancel superseded lint runs on the same ref

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,13 @@ on:
     branches:
       - "**"
 
+# Cancel an in-progress lint run when a newer commit lands on the same ref — the superseded run's
+# result is never useful. Safe here because this workflow only lints, with no release or deploy
+# work that has to run to completion. Mirrors a-novel-kit/.github.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-node:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This workflow only lints — four jobs, no release or deploy work that has to run to completion — so a
run superseded by a newer commit on the same ref produces a result nobody will read. It was still
running to the end.

Adds the `concurrency` group `a-novel-kit/.github` already carries, with the same comment, so the two
org profile repos read the same.

## Required checks

No job was added, renamed or removed.

## Test plan

- [x] `prettier --check` clean
- [x] `zizmor` 1.28.0 clean
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)