### PR TITLE
fix(ci): drop redundant Renovate frozen install

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: a-novel-kit/workflows/generic-actions/renovate@v1.28.1
         with:
-          allowed_commands: '["^go mod tidy && go generate .*", "^go mod tidy && go tool .*", "^go get -u .*", "^pnpm i --frozen-lockfile$"]'
+          allowed_commands: '["^go mod tidy && go generate .*", "^go mod tidy && go tool .*", "^go get -u .*"]'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
           client_id: ${{ vars.DEPENDENCY_BOT_CLIENT_ID }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "packageRules": [
-    {
-      "matchManagers": ["npm"],
-      "postUpgradeTasks": {
-        "commands": ["pnpm i --frozen-lockfile"],
-        "executionMode": "branch"
-      }
-    }
-  ],
   "extends": ["config:recommended"]
 }


### PR DESCRIPTION
## Summary

- Removes the post-upgrade frozen install that reruns after lockfile generation without private-package credentials.
- Keeps Renovate's authenticated lockfile update and normal CI frozen installs as the validation gates.

## Breaking changes

None.

## Test plan

- [x] `pnpm lint:stylecheck` passes
- [ ] CI green