### PR TITLE
docs(profile): show Agora banner

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,8 +1,10 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/a-novel/uikit/master/src/lib/assets/logos/HD/agora%20(dark).png">
-  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/a-novel/uikit/master/src/lib/assets/logos/HD/agora%20(light).png">
-  <img alt="Agora logo." src="https://raw.githubusercontent.com/a-novel/uikit/master/src/lib/assets/logos/HD/agora%20(dark).png">
-</picture>
+<p align="center">
+  <img
+    alt="Agora"
+    src="https://raw.githubusercontent.com/a-novel-kit/uikit/v0.4.0/packages/images/files/banner/1920w/agora-banner.png"
+    width="960"
+  />
+</p>
 
 # ⌨️ We are Agora
 


### PR DESCRIPTION
## Summary

- Replaces obsolete theme-specific logo URLs with the canonical Agora banner from the immutable UIkit 0.4.0 release.
- Keeps the existing organization introduction while presenting the brand consistently at a readable profile width.

## Breaking changes

None.

## Test plan

- [x] `pnpm lint`
- [x] Published banner URL returns PNG content
- [x] Code CI green
- [ ] Epic #317 merge gate releases after both member PRs are approved

Closes #318
