### PR TITLE
chore(deps): use shared Renovate policy

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.30.0
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.30.1
         with:
           allowed_commands: '["^go mod tidy && go generate .*", "^go mod tidy && go tool .*", "^go get -u .*"]'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,3 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
 }


### PR DESCRIPTION
## Summary

- consume workflows v1.30.1 as the canonical Renovate policy
- remove the repo-local recommended preset now owned by the shared action
- remove the repo-local recommended preset now owned by the shared action

## Validation

- jq empty renovate.json
- renovate-config-validator renovate.json
- git diff --check